### PR TITLE
Add support for new `has_object_privilege` API [FE-5403]

### DIFF
--- a/dist/browser-connector.js
+++ b/dist/browser-connector.js
@@ -66,10 +66,27 @@
 		Author Tobias Koppers @sokra
 	*/
 	module.exports = function(src) {
-		if (typeof execScript !== "undefined")
-			execScript(src);
-		else
-			eval.call(null, src);
+		function log(error) {
+			(typeof console !== "undefined")
+			&& (console.error || console.log)("[Script Loader]", error);
+		}
+
+		// Check for IE =< 8
+		function isIE() {
+			return typeof attachEvent !== "undefined" && typeof addEventListener === "undefined";
+		}
+
+		try {
+			if (typeof execScript !== "undefined" && isIE()) {
+				execScript(src);
+			} else if (typeof eval !== "undefined") {
+				eval.call(null, src);
+			} else {
+				log("EvalError: No eval function available");
+			}
+		} catch (error) {
+			log(error);
+		}
 	}
 
 
@@ -149,7 +166,7 @@
 
 	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-	/* global TDashboardPermissions: false, TDBObjectType: false */
+	/* global TDashboardPermissions: false, TDBObjectType: false, TDBObjectPermissions: false, TDatabasePermissions: false */
 
 	var _ref = isNodeRuntime() && __webpack_require__(119) || window,
 	    TDatumType = _ref.TDatumType,
@@ -423,6 +440,25 @@
 	    this.getAllRolesForUserAsync = this.promisifySingle(function (args) {
 	      return args;
 	    }, "get_all_roles_for_user");
+	    this.hasObjectPrivilegesAsync = this.promisifySingle(function (_ref8) {
+	      var _ref9 = _slicedToArray(_ref8, 4),
+	          granteeName = _ref9[0],
+	          dbName = _ref9[1],
+	          objectName = _ref9[2],
+	          permissions = _ref9[3];
+
+	      return [granteeName, dbName, objectName, permissions];
+	    }, "has_object_privilege");
+	    this.hasDbPrivilegesAsync = this.promisifySingle(function (_ref10) {
+	      var _ref11 = _slicedToArray(_ref10, 3),
+	          granteeName = _ref11[0],
+	          dbName = _ref11[1],
+	          dbPrivs = _ref11[2];
+
+	      return [granteeName, dbName, TDBObjectType.DatabaseDBObjectType, new TDBObjectPermissions({
+	        database_permissions_: new TDatabasePermissions(dbPrivs)
+	      })];
+	    }, "has_object_privilege");
 
 	    this.queryAsync = function (query, options) {
 	      return new Promise(function (resolve, reject) {
@@ -1063,6 +1099,17 @@
 	     * Get all the roles assigned to a given username.
 	     * @param {String} username - The username whose roles you wish to get.
 	     * @return {Promise} A list of all roles assigned to the username.
+	     */
+
+
+	    /**
+	     * Specialization of `has_object_privilege` for checking database privileges of a user.
+	     *
+	     * @param {String} granteeName - The name of the user or role to check privileges for.
+	     * @param {String} dbName - The name of the database to check user privileges against.
+	     * @param {TDatabasePermissions} dbPrivs - An object specifying what privileges to check.
+	     *
+	     * @return {Boolean} true if the user/role has all the specified DB privileges, false otherwise.
 	     */
 
 	  }, {

--- a/dist/browser-connector.js
+++ b/dist/browser-connector.js
@@ -443,22 +443,18 @@
 	    this.hasObjectPrivilegesAsync = this.promisifySingle(function (_ref8) {
 	      var _ref9 = _slicedToArray(_ref8, 4),
 	          granteeName = _ref9[0],
-	          dbName = _ref9[1],
-	          objectName = _ref9[2],
+	          objectName = _ref9[1],
+	          objectType = _ref9[2],
 	          permissions = _ref9[3];
 
-	      return [granteeName, dbName, objectName, permissions];
+	      return [granteeName, objectName, objectType, permissions];
 	    }, "has_object_privilege");
-	    this.hasDbPrivilegesAsync = this.promisifySingle(function (_ref10) {
-	      var _ref11 = _slicedToArray(_ref10, 3),
-	          granteeName = _ref11[0],
-	          dbName = _ref11[1],
-	          dbPrivs = _ref11[2];
 
-	      return [granteeName, dbName, TDBObjectType.DatabaseDBObjectType, new TDBObjectPermissions({
+	    this.hasDbPrivilegesAsync = function (granteeName, dbName, dbPrivs) {
+	      return _this.hasObjectPrivilegesAsync(granteeName, dbName, TDBObjectType.DatabaseDBObjectType, new TDBObjectPermissions({
 	        database_permissions_: new TDatabasePermissions(dbPrivs)
-	      })];
-	    }, "has_object_privilege");
+	      }));
+	    };
 
 	    this.queryAsync = function (query, options) {
 	      return new Promise(function (resolve, reject) {
@@ -1103,6 +1099,33 @@
 
 
 	    /**
+	     * Checks if the given user or role has a privilege(s) on a given object. Note that this check is
+	     * transative; if a user has been granted a privilege via a role, this will return `true`.
+	     * @param {String} granteeName - The name of the user or role to check privileges for.
+	     * @param {String} objectName - The name of the object to check privileges against (for example,
+	     * the database name, table name, etc.)
+	     * @param {TDBObjectType} objectType - The type of object to check privileges against.
+	     * @param {TDBObjectPermissions} permissions - An object containing the privileges to check. All
+	     * the privileges specified must be granted for this function to return true.
+	     * @return {Boolean} true if all the specified privileges have been granted to the user/role,
+	     * false otherwise.
+	     *
+	     * @example <caption>Check if user <code>my_user</code> has the "view SQL Editor" privilege on the <code>my_db</code> database:</caption>
+	     *
+	     * con.hasDbPrivilegesAsync(
+	     *   "my_user",
+	     *   "my_db",
+	     *   TDBObjectType.DatabaseDBObjectType,
+	     *   new TDBObjectPermissions({
+	     *     database_permissions_: new TDatabasePermissions(dbPrivs)
+	     *   })
+	     * ).then((res) =>
+	     *   if(res) { console.log("Can view the SQL editor") }
+	     * )
+	     */
+
+
+	    /**
 	     * Specialization of `has_object_privilege` for checking database privileges of a user.
 	     *
 	     * @param {String} granteeName - The name of the user or role to check privileges for.
@@ -1110,6 +1133,12 @@
 	     * @param {TDatabasePermissions} dbPrivs - An object specifying what privileges to check.
 	     *
 	     * @return {Boolean} true if the user/role has all the specified DB privileges, false otherwise.
+	     *
+	     * @example <caption>Check if user <code>my_user</code> has the "view SQL Editor" privilege on the <code>my_db</code> database:</caption>
+	     *
+	     * con.hasDbPrivilegesAsync("my_user", "my_db", {view_sql_editor_: true}).then(res =>
+	     *  if(res) { console.log("Can view the SQL editor") }
+	     * )
 	     */
 
 	  }, {

--- a/dist/node-connector.js
+++ b/dist/node-connector.js
@@ -17205,22 +17205,18 @@ module.exports =
 	    this.hasObjectPrivilegesAsync = this.promisifySingle(function (_ref8) {
 	      var _ref9 = _slicedToArray(_ref8, 4),
 	          granteeName = _ref9[0],
-	          dbName = _ref9[1],
-	          objectName = _ref9[2],
+	          objectName = _ref9[1],
+	          objectType = _ref9[2],
 	          permissions = _ref9[3];
 
-	      return [granteeName, dbName, objectName, permissions];
+	      return [granteeName, objectName, objectType, permissions];
 	    }, "has_object_privilege");
-	    this.hasDbPrivilegesAsync = this.promisifySingle(function (_ref10) {
-	      var _ref11 = _slicedToArray(_ref10, 3),
-	          granteeName = _ref11[0],
-	          dbName = _ref11[1],
-	          dbPrivs = _ref11[2];
 
-	      return [granteeName, dbName, TDBObjectType.DatabaseDBObjectType, new TDBObjectPermissions({
+	    this.hasDbPrivilegesAsync = function (granteeName, dbName, dbPrivs) {
+	      return _this.hasObjectPrivilegesAsync(granteeName, dbName, TDBObjectType.DatabaseDBObjectType, new TDBObjectPermissions({
 	        database_permissions_: new TDatabasePermissions(dbPrivs)
-	      })];
-	    }, "has_object_privilege");
+	      }));
+	    };
 
 	    this.queryAsync = function (query, options) {
 	      return new Promise(function (resolve, reject) {
@@ -17865,6 +17861,33 @@ module.exports =
 
 
 	    /**
+	     * Checks if the given user or role has a privilege(s) on a given object. Note that this check is
+	     * transative; if a user has been granted a privilege via a role, this will return `true`.
+	     * @param {String} granteeName - The name of the user or role to check privileges for.
+	     * @param {String} objectName - The name of the object to check privileges against (for example,
+	     * the database name, table name, etc.)
+	     * @param {TDBObjectType} objectType - The type of object to check privileges against.
+	     * @param {TDBObjectPermissions} permissions - An object containing the privileges to check. All
+	     * the privileges specified must be granted for this function to return true.
+	     * @return {Boolean} true if all the specified privileges have been granted to the user/role,
+	     * false otherwise.
+	     *
+	     * @example <caption>Check if user <code>my_user</code> has the "view SQL Editor" privilege on the <code>my_db</code> database:</caption>
+	     *
+	     * con.hasDbPrivilegesAsync(
+	     *   "my_user",
+	     *   "my_db",
+	     *   TDBObjectType.DatabaseDBObjectType,
+	     *   new TDBObjectPermissions({
+	     *     database_permissions_: new TDatabasePermissions(dbPrivs)
+	     *   })
+	     * ).then((res) =>
+	     *   if(res) { console.log("Can view the SQL editor") }
+	     * )
+	     */
+
+
+	    /**
 	     * Specialization of `has_object_privilege` for checking database privileges of a user.
 	     *
 	     * @param {String} granteeName - The name of the user or role to check privileges for.
@@ -17872,6 +17895,12 @@ module.exports =
 	     * @param {TDatabasePermissions} dbPrivs - An object specifying what privileges to check.
 	     *
 	     * @return {Boolean} true if the user/role has all the specified DB privileges, false otherwise.
+	     *
+	     * @example <caption>Check if user <code>my_user</code> has the "view SQL Editor" privilege on the <code>my_db</code> database:</caption>
+	     *
+	     * con.hasDbPrivilegesAsync("my_user", "my_db", {view_sql_editor_: true}).then(res =>
+	     *  if(res) { console.log("Can view the SQL editor") }
+	     * )
 	     */
 
 	  }, {

--- a/dist/node-connector.js
+++ b/dist/node-connector.js
@@ -16928,7 +16928,7 @@ module.exports =
 
 	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-	/* global TDashboardPermissions: false, TDBObjectType: false */
+	/* global TDashboardPermissions: false, TDBObjectType: false, TDBObjectPermissions: false, TDatabasePermissions: false */
 
 	var _ref = isNodeRuntime() && __webpack_require__(52) || window,
 	    TDatumType = _ref.TDatumType,
@@ -17202,6 +17202,25 @@ module.exports =
 	    this.getAllRolesForUserAsync = this.promisifySingle(function (args) {
 	      return args;
 	    }, "get_all_roles_for_user");
+	    this.hasObjectPrivilegesAsync = this.promisifySingle(function (_ref8) {
+	      var _ref9 = _slicedToArray(_ref8, 4),
+	          granteeName = _ref9[0],
+	          dbName = _ref9[1],
+	          objectName = _ref9[2],
+	          permissions = _ref9[3];
+
+	      return [granteeName, dbName, objectName, permissions];
+	    }, "has_object_privilege");
+	    this.hasDbPrivilegesAsync = this.promisifySingle(function (_ref10) {
+	      var _ref11 = _slicedToArray(_ref10, 3),
+	          granteeName = _ref11[0],
+	          dbName = _ref11[1],
+	          dbPrivs = _ref11[2];
+
+	      return [granteeName, dbName, TDBObjectType.DatabaseDBObjectType, new TDBObjectPermissions({
+	        database_permissions_: new TDatabasePermissions(dbPrivs)
+	      })];
+	    }, "has_object_privilege");
 
 	    this.queryAsync = function (query, options) {
 	      return new Promise(function (resolve, reject) {
@@ -17842,6 +17861,17 @@ module.exports =
 	     * Get all the roles assigned to a given username.
 	     * @param {String} username - The username whose roles you wish to get.
 	     * @return {Promise} A list of all roles assigned to the username.
+	     */
+
+
+	    /**
+	     * Specialization of `has_object_privilege` for checking database privileges of a user.
+	     *
+	     * @param {String} granteeName - The name of the user or role to check privileges for.
+	     * @param {String} dbName - The name of the database to check user privileges against.
+	     * @param {TDatabasePermissions} dbPrivs - An object specifying what privileges to check.
+	     *
+	     * @return {Boolean} true if the user/role has all the specified DB privileges, false otherwise.
 	     */
 
 	  }, {

--- a/src/mapd-con-es6.js
+++ b/src/mapd-con-es6.js
@@ -1,4 +1,4 @@
-/* global TDashboardPermissions: false, TDBObjectType: false */
+/* global TDashboardPermissions: false, TDBObjectType: false, TDBObjectPermissions: false, TDatabasePermissions: false */
 
 const { TDatumType, TEncodingType, TPixel } =
   (isNodeRuntime() && require("../build/thrift/node/mapd_types.js")) || window // eslint-disable-line global-require
@@ -881,6 +881,37 @@ class MapdCon {
   getAllRolesForUserAsync = this.promisifySingle(
     args => args,
     "get_all_roles_for_user"
+  )
+
+  hasObjectPrivilegesAsync = this.promisifySingle(
+    ([granteeName, dbName, objectName, permissions]) => [
+      granteeName,
+      dbName,
+      objectName,
+      permissions
+    ],
+    "has_object_privilege"
+  )
+
+  /**
+   * Specialization of `has_object_privilege` for checking database privileges of a user.
+   *
+   * @param {String} granteeName - The name of the user or role to check privileges for.
+   * @param {String} dbName - The name of the database to check user privileges against.
+   * @param {TDatabasePermissions} dbPrivs - An object specifying what privileges to check.
+   *
+   * @return {Boolean} true if the user/role has all the specified DB privileges, false otherwise.
+   */
+  hasDbPrivilegesAsync = this.promisifySingle(
+    ([granteeName, dbName, dbPrivs]) => [
+      granteeName,
+      dbName,
+      TDBObjectType.DatabaseDBObjectType,
+      new TDBObjectPermissions({
+        database_permissions_: new TDatabasePermissions(dbPrivs)
+      })
+    ],
+    "has_object_privilege"
   )
 
   /**

--- a/src/mapd-con-es6.js
+++ b/src/mapd-con-es6.js
@@ -883,11 +883,36 @@ class MapdCon {
     "get_all_roles_for_user"
   )
 
+  /**
+   * Checks if the given user or role has a privilege(s) on a given object. Note that this check is
+   * transative; if a user has been granted a privilege via a role, this will return `true`.
+   * @param {String} granteeName - The name of the user or role to check privileges for.
+   * @param {String} objectName - The name of the object to check privileges against (for example,
+   * the database name, table name, etc.)
+   * @param {TDBObjectType} objectType - The type of object to check privileges against.
+   * @param {TDBObjectPermissions} permissions - An object containing the privileges to check. All
+   * the privileges specified must be granted for this function to return true.
+   * @return {Boolean} true if all the specified privileges have been granted to the user/role,
+   * false otherwise.
+   *
+   * @example <caption>Check if user <code>my_user</code> has the "view SQL Editor" privilege on the <code>my_db</code> database:</caption>
+   *
+   * con.hasDbPrivilegesAsync(
+   *   "my_user",
+   *   "my_db",
+   *   TDBObjectType.DatabaseDBObjectType,
+   *   new TDBObjectPermissions({
+   *     database_permissions_: new TDatabasePermissions(dbPrivs)
+   *   })
+   * ).then((res) =>
+   *   if(res) { console.log("Can view the SQL editor") }
+   * )
+   */
   hasObjectPrivilegesAsync = this.promisifySingle(
-    ([granteeName, dbName, objectName, permissions]) => [
+    ([granteeName, objectName, objectType, permissions]) => [
       granteeName,
-      dbName,
       objectName,
+      objectType,
       permissions
     ],
     "has_object_privilege"
@@ -901,18 +926,22 @@ class MapdCon {
    * @param {TDatabasePermissions} dbPrivs - An object specifying what privileges to check.
    *
    * @return {Boolean} true if the user/role has all the specified DB privileges, false otherwise.
+   *
+   * @example <caption>Check if user <code>my_user</code> has the "view SQL Editor" privilege on the <code>my_db</code> database:</caption>
+   *
+   * con.hasDbPrivilegesAsync("my_user", "my_db", {view_sql_editor_: true}).then(res =>
+   *  if(res) { console.log("Can view the SQL editor") }
+   * )
    */
-  hasDbPrivilegesAsync = this.promisifySingle(
-    ([granteeName, dbName, dbPrivs]) => [
+  hasDbPrivilegesAsync = (granteeName, dbName, dbPrivs) =>
+    this.hasObjectPrivilegesAsync(
       granteeName,
       dbName,
       TDBObjectType.DatabaseDBObjectType,
       new TDBObjectPermissions({
         database_permissions_: new TDatabasePermissions(dbPrivs)
       })
-    ],
-    "has_object_privilege"
-  )
+    )
 
   /**
    * Asynchronously get data from an importable file,


### PR DESCRIPTION
This PR adds support for the new backend API, `has_object_privilege`. It additionally adds a convenience function, `hasDbPrivilegesAsync`, that specializes that API call for use with DB object queries, as a convenience/syntactic sugar.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [x] Author referenced issue(s) fixed by this PR:
- [x] Fixes FE-5403

## :smoking: Smoke Test
- [x] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
