### PR TITLE
Add default TCreateParams as new import_geo_table() parameter

### DIFF
--- a/src/mapd-con-es6.js
+++ b/src/mapd-con-es6.js
@@ -1246,12 +1246,14 @@ class MapdCon {
 
     for (let c = 0; c < this._numConnections; c++) {
       if (isShapeFile) {
+        TCreateParams thriftCreateParamsDefault; // is_replicated = false
         this._client[c].import_geo_table(
           this._sessionId[c],
           tableName,
           fileName,
           thriftCopyParams,
           thriftRowDesc,
+          thriftCreateParamsDefault,
           thriftCallBack
         )
       } else {


### PR DESCRIPTION
Where is the Javascript-side master `mapd.thrift` file that I need to change too?!

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
