### PR TITLE
[FE-7953] Bump float precision from 7 to 9

### DIFF
--- a/dist/browser-connector.js
+++ b/dist/browser-connector.js
@@ -1899,7 +1899,7 @@
 	});
 	exports.timestampToMs = timestampToMs;
 	exports.realToDecimal = realToDecimal;
-	var CORE_CPP_FLOAT_PRECISION = exports.CORE_CPP_FLOAT_PRECISION = 7;
+	var CORE_CPP_FLOAT_PRECISION = exports.CORE_CPP_FLOAT_PRECISION = 9;
 	var CORE_CPP_DOUBLE_PRECISION = exports.CORE_CPP_DOUBLE_PRECISION = 16;
 
 	var convertObjectToThriftCopyParams = exports.convertObjectToThriftCopyParams = function convertObjectToThriftCopyParams(obj) {
@@ -1943,7 +1943,7 @@
 	 *  that as per FE-5318 this will default to 7 (i.e. `std::numeric_limits<float>::digits10 + 1`)
 	 *  to match core
 	 * @returns {Double} - The equivalent decimal number encoded in a double precision number
-	*/
+	 */
 	function realToDecimal(real, precision) {
 	  return Number(Number.parseFloat(real).toPrecision(precision));
 	}

--- a/dist/node-connector.js
+++ b/dist/node-connector.js
@@ -18860,7 +18860,7 @@ module.exports =
 	});
 	exports.timestampToMs = timestampToMs;
 	exports.realToDecimal = realToDecimal;
-	var CORE_CPP_FLOAT_PRECISION = exports.CORE_CPP_FLOAT_PRECISION = 7;
+	var CORE_CPP_FLOAT_PRECISION = exports.CORE_CPP_FLOAT_PRECISION = 9;
 	var CORE_CPP_DOUBLE_PRECISION = exports.CORE_CPP_DOUBLE_PRECISION = 16;
 
 	var convertObjectToThriftCopyParams = exports.convertObjectToThriftCopyParams = function convertObjectToThriftCopyParams(obj) {
@@ -18904,7 +18904,7 @@ module.exports =
 	 *  that as per FE-5318 this will default to 7 (i.e. `std::numeric_limits<float>::digits10 + 1`)
 	 *  to match core
 	 * @returns {Double} - The equivalent decimal number encoded in a double precision number
-	*/
+	 */
 	function realToDecimal(real, precision) {
 	  return Number(Number.parseFloat(real).toPrecision(precision));
 	}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,4 +1,4 @@
-export const CORE_CPP_FLOAT_PRECISION = 7
+export const CORE_CPP_FLOAT_PRECISION = 9
 export const CORE_CPP_DOUBLE_PRECISION = 16
 
 export const convertObjectToThriftCopyParams = obj => new TCopyParams(obj) // eslint-disable-line no-undef
@@ -40,7 +40,7 @@ export function timestampToMs(timestamp, precision) {
  *  that as per FE-5318 this will default to 7 (i.e. `std::numeric_limits<float>::digits10 + 1`)
  *  to match core
  * @returns {Double} - The equivalent decimal number encoded in a double precision number
-*/
+ */
 export function realToDecimal(real, precision) {
   return Number(Number.parseFloat(real).toPrecision(precision))
 }

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -553,7 +553,7 @@ describe(isNodeRuntime ? "node" : "browser", () => {
           (pixelError, data) => {
             expect(pixelError).to.not.be.an("error")
             const lon = data[0].row_set[0].dest_lon
-            expect(lon).to.equal(-119.0568) // Ran 100 times; seems deterministic.
+            expect(lon).to.equal(-119.05677) // Ran 100 times; seems deterministic.
             done()
           }
         )


### PR DESCRIPTION
Jira issue: https://jira.omnisci.com/browse/FE-7953

Bump significant digits of floating-point precision used for the float type (not double, just float) from 7 up to 9, to accommodate greater precision (important when the values might be used for spatial rendering, rather than just text output), at the cost of potentially misformatted text output that doesn't exactly match the original values.