### PR TITLE
[FE-8720] Fix a bug that prevented connector from working properly under Node.js

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+thrift/
+build/
+dist/

--- a/dist/browser-connector.js
+++ b/dist/browser-connector.js
@@ -288,7 +288,19 @@
 	      };
 	    };
 
-	    this.promisifyThriftMethod = function (client, sessionId, methodName, args) {
+	    this.promisifyThriftMethodNode = function (client, sessionId, methodName, args) {
+	      return new Promise(function (resolve, reject) {
+	        client[methodName].apply(client, [sessionId].concat(args, function (err, result) {
+	          if (err) {
+	            reject(err);
+	          } else {
+	            resolve(result);
+	          }
+	        }));
+	      });
+	    };
+
+	    this.promisifyThriftMethodBrowser = function (client, sessionId, methodName, args) {
 	      return new Promise(function (resolve, reject) {
 	        client[methodName].apply(client, [sessionId].concat(args, function (result) {
 	          if (result instanceof Error) {
@@ -300,6 +312,7 @@
 	      });
 	    };
 
+	    this.promisifyThriftMethod = isNodeRuntime() ? this.promisifyThriftMethodNode : this.promisifyThriftMethodBrowser;
 	    this.overSingleClient = "SINGLE_CLIENT";
 	    this.overAllClients = "ALL_CLIENTS";
 

--- a/dist/node-connector.js
+++ b/dist/node-connector.js
@@ -18682,7 +18682,19 @@ module.exports =
 	      };
 	    };
 
-	    this.promisifyThriftMethod = function (client, sessionId, methodName, args) {
+	    this.promisifyThriftMethodNode = function (client, sessionId, methodName, args) {
+	      return new Promise(function (resolve, reject) {
+	        client[methodName].apply(client, [sessionId].concat(args, function (err, result) {
+	          if (err) {
+	            reject(err);
+	          } else {
+	            resolve(result);
+	          }
+	        }));
+	      });
+	    };
+
+	    this.promisifyThriftMethodBrowser = function (client, sessionId, methodName, args) {
 	      return new Promise(function (resolve, reject) {
 	        client[methodName].apply(client, [sessionId].concat(args, function (result) {
 	          if (result instanceof Error) {
@@ -18694,6 +18706,7 @@ module.exports =
 	      });
 	    };
 
+	    this.promisifyThriftMethod = isNodeRuntime() ? this.promisifyThriftMethodNode : this.promisifyThriftMethodBrowser;
 	    this.overSingleClient = "SINGLE_CLIENT";
 	    this.overAllClients = "ALL_CLIENTS";
 

--- a/examples/node.js
+++ b/examples/node.js
@@ -22,6 +22,7 @@ connector
   .then(session =>
     // now that we have a session open we can make some db calls:
     Promise.all([
+      session.getDashboardsAsync(),
       session.getTablesAsync(),
       session.getFieldsAsync("flights_donotmodify"),
       session.queryAsync(query, defaultQueryOptions),
@@ -30,25 +31,31 @@ connector
   )
   // values is an array of results from all the promises above
   .then(values => {
+    // handle result of getDashboardsAsync
+    console.log(
+      "All dashboards available at metis.mapd.com:\n",
+      values[0].map(dash => dash.dashboard_name)
+    )
+
     // handle result of getTablesAsync
     console.log(
-      "All tables available at metis.mapd.com:\n\n",
-      values[0].map(x => x.name)
+      "\nAll tables available at metis.mapd.com:\n\n",
+      values[1].map(x => x.name)
     )
 
     // handle result of getFieldsAsync
     console.log(
       "\nAll fields for 'flights_donotmodify':\n\n",
-      values[1].reduce((o, x) => Object.assign(o, { [x.name]: x }), {})
+      values[2].columns.reduce((o, x) => Object.assign(o, { [x.name]: x }), {})
     )
 
     // handle result of first query
-    console.log("\nQuery 1 results:\n\n", Number(values[2][0].n))
+    console.log("\nQuery 1 results:\n\n", Number(values[3][0].n))
 
     // handle result of second query
     console.log(
       "\nQuery 2 results:\n\n",
-      values[3].reduce((o, x) => Object.assign(o, { [x.key0]: x.val }), {})
+      values[4].reduce((o, x) => Object.assign(o, { [x.key0]: x.val }), {})
     )
   })
   .catch(error => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapd/connector",
-  "version": "4.4.0",
+  "version": "4.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2149,7 +2149,8 @@
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
       "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "cssstyle": {
       "version": "0.2.37",
@@ -3491,7 +3492,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3512,12 +3514,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3532,17 +3536,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3659,7 +3666,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3671,6 +3679,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3685,6 +3694,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3692,12 +3702,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3716,6 +3728,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3803,7 +3816,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3815,6 +3829,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3900,7 +3915,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3936,6 +3952,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3955,6 +3972,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3998,12 +4016,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6428,6 +6448,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -7177,7 +7198,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapd/connector",
-  "version": "4.7.0",
+  "version": "4.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapd/connector",
   "description": "Connector to mapdql",
-  "version": "4.7.0",
+  "version": "4.7.2",
   "license": "Apache-2.0",
   "scripts": {
     "build": "bash scripts/build.sh",

--- a/src/mapd-con-es6.js
+++ b/src/mapd-con-es6.js
@@ -367,7 +367,21 @@ class MapdCon {
       })
     })
 
-  promisifyThriftMethod = (client, sessionId, methodName, args) =>
+  promisifyThriftMethodNode = (client, sessionId, methodName, args) =>
+    new Promise((resolve, reject) => {
+      client[methodName].apply(
+        client,
+        [sessionId].concat(args, (err, result) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve(result)
+          }
+        })
+      )
+    })
+
+  promisifyThriftMethodBrowser = (client, sessionId, methodName, args) =>
     new Promise((resolve, reject) => {
       client[methodName].apply(
         client,
@@ -380,6 +394,10 @@ class MapdCon {
         })
       )
     })
+
+  promisifyThriftMethod = isNodeRuntime()
+    ? this.promisifyThriftMethodNode
+    : this.promisifyThriftMethodBrowser
 
   overSingleClient = "SINGLE_CLIENT"
   overAllClients = "ALL_CLIENTS"

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -107,6 +107,77 @@ describe(isNodeRuntime ? "node" : "browser", () => {
     })
   })
 
+  // Note that this test assumes the list of dashboards (and their metadata) on Metis aren't
+  // changed. If they do change, this test will fail. The only exception is each dash's
+  // `update_time`, which we filter out since that is too volatile to rely on.
+  it(".getDashboardsAsync", done => {
+    connector.connect((connectError, session) => {
+      expect(connectError).to.not.be.an("error")
+      session
+        .getDashboardsAsync()
+        // eslint-disable-next-line max-nested-callbacks
+        .then(data => {
+          // The `update_time` field is too volatile to rely on for unit tests, so strip it out
+          const dataNoUpdateTime = data.map(d =>
+            Object.assign({}, d, { update_time: null })
+          )
+          expect(dataNoUpdateTime).to.deep.equal([
+            {
+              dashboard_name: "__E2E_LINE_CHART_BRUSH__DO_NOT_MODIFY__",
+              dashboard_state: "",
+              image_hash: "",
+              update_time: null,
+              dashboard_metadata:
+                '{"table":"flights_donotmodify","version":"v2"}',
+              dashboard_id: 452,
+              dashboard_owner: "mapd",
+              is_dash_shared: false
+            },
+            {
+              dashboard_name:
+                "__E2E_MULTI_BIN_DIM_HEATMAP_FILTER__DO_NOT_MODIFY__",
+              dashboard_state: "",
+              image_hash: "",
+              update_time: null,
+              dashboard_metadata:
+                '{"table":"flights_donotmodify","version":"v2"}',
+              dashboard_id: 451,
+              dashboard_owner: "mapd",
+              is_dash_shared: false
+            },
+            {
+              dashboard_name: "__E2E_NUMBER_CHART__DO_NOT_MODIFY__",
+              dashboard_state: "",
+              image_hash: "",
+              update_time: null,
+              dashboard_metadata:
+                '{"table":"flights_donotmodify","version":"v2"}',
+              dashboard_id: 450,
+              dashboard_owner: "mapd",
+              is_dash_shared: false
+            },
+            {
+              dashboard_name: "__E2E__ALL_CHARTS__DO_NOT_MODIFY__",
+              dashboard_state: "",
+              image_hash: "",
+              update_time: null,
+              dashboard_metadata:
+                '{"table":"contributions_donotmodify","version":"v2"}',
+              dashboard_id: 449,
+              dashboard_owner: "mapd",
+              is_dash_shared: false
+            }
+          ])
+          done()
+        })
+        // eslint-disable-next-line max-nested-callbacks
+        .catch(getDashboardsAsyncError => {
+          expect(getDashboardsAsyncError).to.not.be.an("error")
+          done()
+        })
+    })
+  })
+
   it(".getFields", done => {
     connector.connect((connectError, session) => {
       expect(connectError).to.not.be.an("error")


### PR DESCRIPTION
The Node.js Thrift bindings use a different callback format than the browser-flavored JS version: `fn(err, results) {...}` instead of `fn(results)`. Connector wasn't aware of this, and so would only look at the first argument to the callback when passing back function call results to the caller. When there was no error, this would simply be `null`, leading to a bug where all functions seemingly refused to ever return data.

This commit specializes the `promisifyThriftMethod` wrapper function for both the browser and node.js. The browser version is the same as the existing function. The node.js version changes the callback arg format to what's described above. The runtime then dynamically chooses one specialization or the other based on the `isNodeRuntime()` function.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Fixes FE-8720

## :smoking: Smoke Test
- [x] Works in chrome
- [x] Works in Node.js

## :ship: Merge
- [x] author crafted PR's title into release-worthy commit message.
