### PR TITLE
Add some more event types out of 'events' EventEmitter

### DIFF
--- a/dist/node-connector.js
+++ b/dist/node-connector.js
@@ -18701,10 +18701,16 @@ module.exports =
 
 	    this.promisifyThriftMethodBrowser = function (client, sessionId, methodName, args) {
 	      return new Promise(function (resolve, reject) {
+	        var start = performance.now();
 	        client[methodName].apply(client, [sessionId].concat(args, function (result) {
 	          if (result instanceof Error) {
 	            reject(result);
 	          } else {
+	            _this.events.emit("thrift-timing", {
+	              method: methodName,
+	              args: args,
+	              time: performance.now() - start
+	            });
 	            resolve(result);
 	          }
 	        }));
@@ -19023,10 +19029,11 @@ module.exports =
 	      if (error) {
 	        if (_this._logging && options.query) {
 	          console.error(options.query, "\n", error);
+	          _this.events.emit("query-error", { query: options.query, error: error });
 	        }
 	        callback(error);
 	      } else {
-	        var processor = (0, _processQueryResults2.default)(_this._logging, _this.updateQueryTimes);
+	        var processor = (0, _processQueryResults2.default)(_this._logging, _this.updateQueryTimes, _this.events);
 	        var processResultsObject = processor(options, _this._datumEnum, result, callback);
 	        return processResultsObject;
 	      }
@@ -21123,6 +21130,7 @@ module.exports =
 	 *
 	 * @param {Boolean} logging If enabled, shows on the console how long the query took to run.
 	 * @param {Function} updateQueryTimes A function that updates internal query times on the connector.
+	 * @param {Object} events The EventEmitter to log to.
 	 * @param {Object} options A list of options for processing the results.
 	 * @param {Boolean} options.isImage Set to true when querying for backend-rendered images.
 	 * @param {Boolean} options.eliminateNullRows Removes null rows.
@@ -21136,7 +21144,7 @@ module.exports =
 	 * @return {Object} Null if image with callbacks, result if image with callbacks,
 	 *                  otherwise formatted results.
 	 */
-	function processQueryResults(logging, updateQueryTimes) {
+	function processQueryResults(logging, updateQueryTimes, events) {
 	  return function (options, _datumEnum, result, callback) {
 	    var isImage = false;
 	    var eliminateNullRows = false;
@@ -21161,6 +21169,7 @@ module.exports =
 	    // should use node_env
 	    if (logging && result.execution_time_ms) {
 	      console.log(query, "on Server", conId, "- Execution Time:", result.execution_time_ms, " ms, Total Time:", result.total_time_ms + "ms");
+	      events.emit("query", { query: query, result: result });
 	    }
 
 	    if (isImage && hasCallback) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2149,7 +2149,8 @@
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
       "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "cssstyle": {
       "version": "0.2.37",
@@ -3105,9 +3106,9 @@
       }
     },
     "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+      "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
     },
     "events": {
       "version": "1.1.1",
@@ -3491,7 +3492,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3512,12 +3514,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3532,17 +3536,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3659,7 +3666,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3671,6 +3679,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3685,6 +3694,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3692,12 +3702,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3716,6 +3728,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3803,7 +3816,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3815,6 +3829,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3900,7 +3915,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3936,6 +3952,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3955,6 +3972,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3998,12 +4016,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4615,6 +4635,14 @@
         "eventemitter3": "^3.0.0",
         "follow-redirects": "^1.0.0",
         "requires-port": "^1.0.0"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+          "dev": true
+        }
       }
     },
     "http-signature": {
@@ -6428,6 +6456,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -7177,7 +7206,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "codecov": "^2.2.0",
-    "eventemitter3": "^3.1.0",
+    "eventemitter3": "^4.0.0",
     "ramda.clone": "^0.26.1",
     "script-loader": "^0.7.0",
     "thrift": "^0.10.0"

--- a/src/process-query-results.js
+++ b/src/process-query-results.js
@@ -5,6 +5,7 @@ import processRowResults from "./process-row-results"
  *
  * @param {Boolean} logging If enabled, shows on the console how long the query took to run.
  * @param {Function} updateQueryTimes A function that updates internal query times on the connector.
+ * @param {Object} events The EventEmitter to log to.
  * @param {Object} options A list of options for processing the results.
  * @param {Boolean} options.isImage Set to true when querying for backend-rendered images.
  * @param {Boolean} options.eliminateNullRows Removes null rows.
@@ -18,7 +19,7 @@ import processRowResults from "./process-row-results"
  * @return {Object} Null if image with callbacks, result if image with callbacks,
  *                  otherwise formatted results.
  */
-export default function processQueryResults(logging, updateQueryTimes) {
+export default function processQueryResults(logging, updateQueryTimes, events) {
   return function(options, _datumEnum, result, callback) {
     let isImage = false
     let eliminateNullRows = false
@@ -65,6 +66,7 @@ export default function processQueryResults(logging, updateQueryTimes) {
         " ms, Total Time:",
         result.total_time_ms + "ms"
       )
+      events.emit("query", { query, result })
     }
 
     if (isImage && hasCallback) {


### PR DESCRIPTION
Adds some more events to be published onto the `this.events` EventEmitter:

### "query"
```
{
  query (String): The SQL query string or Vega JSON string requested
  result (Object): The result object with data and execution timing from core
}
```
Fires whenever a SQL or Vega render query _successfully_ returns.
This is the same event logged out to the console when `this.logging(true)` is called.

### "query-error"
```
{
  query (String): The SQL query string or Vega JSON string requested
  error (Error object): The Error object with the reason for the failure
}
```
Fires whenever a SQL or Vega render query returns an error

### "thrift-timing"
```
{
  method (String): The name of the Thrift method called
  args (Array): The arguments the Thrift method was called with
  timing (number): The milliseconds elapsed between calling the Thrift runtime method,
                   and getting the result callback from the Thrift runtime
}
```
Fires for every Thrift method upon successful return.
