### PR TITLE
[FE-10084] Remove unused createResultError

### DIFF
--- a/src/wrap-with-error-handling.js
+++ b/src/wrap-with-error-handling.js
@@ -1,24 +1,11 @@
 const MapDClient =
   (typeof window !== "undefined" && window.MapDClient) ||
   require("../build/thrift/node/mapd.thrift.js").Client // eslint-disable-line global-require
-const TMapDException =
-  (typeof window !== "undefined" && window.TMapDException) ||
-  require("../build/thrift/node/mapd_types.js").TMapDException // eslint-disable-line global-require
 const Thrift =
   (typeof window !== "undefined" && window.Thrift) || require("thrift").Thrift // eslint-disable-line global-require
 
 export function isResultError(result) {
   return result instanceof Thrift.TException || result instanceof Error
-}
-
-export function createResultError(result) {
-  if (result instanceof TMapDException) {
-    return new Error(result.error_msg)
-  } else if (typeof result.message === "undefined") {
-    return new Error("Unspecified Error")
-  } else {
-    return new Error(result.message)
-  }
 }
 
 /* eslint-disable consistent-this */


### PR DESCRIPTION
Minor cleanup; found unreferenced `createResultError` while grepping around.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
