### PR TITLE
[FE-10764] Make test host and credentials configurable

### DIFF
--- a/examples/browser.js
+++ b/examples/browser.js
@@ -1,5 +1,9 @@
 /* eslint-disable */
 
+const hostname = process.env.HOSTNAME || "metis.mapd.com"
+const protocol = process.env.PROTOCOL || "https"
+const port = process.env.PORT || "443"
+
 // The total number of tweets from Columbia
 const query = "SELECT count(*) AS n FROM tweets_nov_feb WHERE country='CO'"
 // try changing airtime to arrdelay in the query
@@ -9,9 +13,9 @@ const defaultQueryOptions = {}
 const connector = new window.MapdCon()
 
 connector
-  .protocol("https")
-  .host("metis.mapd.com")
-  .port("443")
+  .protocol(protocol)
+  .host(hostname)
+  .port(port)
   .dbName("mapd")
   .user("mapd")
   .password("HyperInteractive")
@@ -29,7 +33,7 @@ connector
   .then(values => {
     // handle result of getTablesAsync
     console.log(
-      "All tables available at metis.mapd.com:",
+      `All dashboards available at ${hostname}:\n`,
       values[0].map(x => x.name)
     )
 

--- a/examples/browser.js
+++ b/examples/browser.js
@@ -3,6 +3,9 @@
 const hostname = process.env.HOSTNAME || "metis.mapd.com"
 const protocol = process.env.PROTOCOL || "https"
 const port = process.env.PORT || "443"
+const database = process.env.DATABASE || "mapd"
+const username = process.env.USERNAME || "mapd"
+const password = process.env.PASSWORD || "HyperInteractive"
 
 // The total number of tweets from Columbia
 const query = "SELECT count(*) AS n FROM tweets_nov_feb WHERE country='CO'"
@@ -16,9 +19,9 @@ connector
   .protocol(protocol)
   .host(hostname)
   .port(port)
-  .dbName("mapd")
-  .user("mapd")
-  .password("HyperInteractive")
+  .dbName(database)
+  .user(username)
+  .password(password)
   .connectAsync()
   .then(session =>
     // now that we have a session open we can make some db calls:

--- a/examples/node.js
+++ b/examples/node.js
@@ -2,6 +2,10 @@
 
 const Connector = require("../dist/node-connector.js")
 
+const hostname = process.env.HOSTNAME || "metis.mapd.com"
+const protocol = process.env.PROTOCOL || "https"
+const port = process.env.PORT || "443"
+
 // The total number of tweets from Columbia
 const query = "SELECT count(*) AS n FROM tweets_nov_feb WHERE country='CO'"
 const query2 =
@@ -10,11 +14,10 @@ const defaultQueryOptions = {}
 
 const connector = new Connector()
 
-
 connector
-  .protocol("https")
-  .host("metis.mapd.com")
-  .port("443")
+  .protocol(protocol)
+  .host(hostname)
+  .port(port)
   .dbName("mapd")
   .user("mapd")
   .password("HyperInteractive")
@@ -33,13 +36,13 @@ connector
   .then(values => {
     // handle result of getDashboardsAsync
     console.log(
-      "All dashboards available at metis.mapd.com:\n",
+      `All dashboards available at ${hostname}:\n`,
       values[0].map(dash => dash.dashboard_name)
     )
 
     // handle result of getTablesAsync
     console.log(
-      "\nAll tables available at metis.mapd.com:\n\n",
+      `\nAll tables available at ${hostname}:\n\n`,
       values[1].map(x => x.name)
     )
 

--- a/examples/node.js
+++ b/examples/node.js
@@ -5,6 +5,9 @@ const Connector = require("../dist/node-connector.js")
 const hostname = process.env.HOSTNAME || "metis.mapd.com"
 const protocol = process.env.PROTOCOL || "https"
 const port = process.env.PORT || "443"
+const database = process.env.DATABASE || "mapd"
+const username = process.env.USERNAME || "mapd"
+const password = process.env.PASSWORD || "HyperInteractive"
 
 // The total number of tweets from Columbia
 const query = "SELECT count(*) AS n FROM tweets_nov_feb WHERE country='CO'"
@@ -18,9 +21,9 @@ connector
   .protocol(protocol)
   .host(hostname)
   .port(port)
-  .dbName("mapd")
-  .user("mapd")
-  .password("HyperInteractive")
+  .dbName(database)
+  .user(username)
+  .password(password)
   .connectAsync()
   .then(session =>
     // now that we have a session open we can make some db calls:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1421,7 +1421,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -5708,7 +5709,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
       }
@@ -7074,7 +7076,8 @@
         },
         "fill-range": {
           "version": "2.2.3",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+          "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
           "dev": true,
           "requires": {
             "is-number": "^2.1.0",
@@ -7488,7 +7491,8 @@
         },
         "lodash": {
           "version": "4.17.4",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         },
         "loose-envify": {
@@ -9484,7 +9488,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -1,4 +1,8 @@
 "use strict"
+const hostname = process.env.HOSTNAME || "metis.mapd.com"
+const protocol = process.env.PROTOCOL || "https"
+const port = process.env.PORT || "443"
+
 const isNodeRuntime = typeof window === "undefined"
 const expect = isNodeRuntime ? require("chai").expect : window.expect
 const convertToDataUrl = isNodeRuntime
@@ -18,9 +22,9 @@ describe(isNodeRuntime ? "node" : "browser", () => {
   let connector
   beforeEach(() => {
     connector = new Connector()
-      .protocol("https")
-      .host("metis.mapd.com")
-      .port("443")
+      .protocol(protocol)
+      .host(hostname)
+      .port(port)
       .dbName("mapd")
       .user("mapd")
       .password("HyperInteractive")
@@ -92,12 +96,7 @@ describe(isNodeRuntime ? "node" : "browser", () => {
       session
         .getTablesAsync()
         .then(data => {
-          expect(data).to.deep.equal([
-            { name: "flights_donotmodify", label: "obs" },
-            { name: "contributions_donotmodify", label: "obs" },
-            { name: "tweets_nov_feb", label: "obs" },
-            { name: "zipcodes", label: "obs" }
-          ])
+          expect(data).to.not.be.empty
           done()
         })
         .catch(getTablesAsyncError => {
@@ -107,9 +106,6 @@ describe(isNodeRuntime ? "node" : "browser", () => {
     })
   })
 
-  // Note that this test assumes the list of dashboards (and their metadata) on Metis aren't
-  // changed. If they do change, this test will fail. The only exception is each dash's
-  // `update_time`, which we filter out since that is too volatile to rely on.
   it(".getDashboardsAsync", done => {
     connector.connect((connectError, session) => {
       expect(connectError).to.not.be.an("error")
@@ -121,53 +117,7 @@ describe(isNodeRuntime ? "node" : "browser", () => {
           const dataNoUpdateTime = data.map(d =>
             Object.assign({}, d, { update_time: null })
           )
-          expect(dataNoUpdateTime).to.deep.equal([
-            {
-              dashboard_name: "__E2E_LINE_CHART_BRUSH__DO_NOT_MODIFY__",
-              dashboard_state: "",
-              image_hash: "",
-              update_time: null,
-              dashboard_metadata:
-                '{"table":"flights_donotmodify","version":"v2"}',
-              dashboard_id: 452,
-              dashboard_owner: "mapd",
-              is_dash_shared: false
-            },
-            {
-              dashboard_name:
-                "__E2E_MULTI_BIN_DIM_HEATMAP_FILTER__DO_NOT_MODIFY__",
-              dashboard_state: "",
-              image_hash: "",
-              update_time: null,
-              dashboard_metadata:
-                '{"table":"flights_donotmodify","version":"v2"}',
-              dashboard_id: 451,
-              dashboard_owner: "mapd",
-              is_dash_shared: false
-            },
-            {
-              dashboard_name: "__E2E_NUMBER_CHART__DO_NOT_MODIFY__",
-              dashboard_state: "",
-              image_hash: "",
-              update_time: null,
-              dashboard_metadata:
-                '{"table":"flights_donotmodify","version":"v2"}',
-              dashboard_id: 450,
-              dashboard_owner: "mapd",
-              is_dash_shared: false
-            },
-            {
-              dashboard_name: "__E2E__ALL_CHARTS__DO_NOT_MODIFY__",
-              dashboard_state: "",
-              image_hash: "",
-              update_time: null,
-              dashboard_metadata:
-                '{"table":"contributions_donotmodify","version":"v2"}',
-              dashboard_id: 449,
-              dashboard_owner: "mapd",
-              is_dash_shared: false
-            }
-          ])
+          expect(dataNoUpdateTime).to.not.be.empty
           done()
         })
         // eslint-disable-next-line max-nested-callbacks

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -2,6 +2,9 @@
 const hostname = process.env.HOSTNAME || "metis.mapd.com"
 const protocol = process.env.PROTOCOL || "https"
 const port = process.env.PORT || "443"
+const database = process.env.DATABASE || "mapd"
+const username = process.env.USERNAME || "mapd"
+const password = process.env.PASSWORD || "HyperInteractive"
 
 const isNodeRuntime = typeof window === "undefined"
 const expect = isNodeRuntime ? require("chai").expect : window.expect
@@ -25,9 +28,9 @@ describe(isNodeRuntime ? "node" : "browser", () => {
       .protocol(protocol)
       .host(hostname)
       .port(port)
-      .dbName("mapd")
-      .user("mapd")
-      .password("HyperInteractive")
+      .dbName(database)
+      .user(username)
+      .password(password)
   })
 
   const widgetId = 0


### PR DESCRIPTION
Tests can be ran against hosts other than `https://metis.mapd.com:443` with custom credentials.

`PROTOCOL`, `HOSTNAME`, `PORT`, `USERNAME`, `PASSWORD`, and `DATABASE` are optional variables that can be used when running the integration tests or example files to use other hosts and crederntials. The default values correspond with the original `metis` host values and credentials.

Tests have been updated to check for dashboard and table existence instead of the precise values.

The above changes were verified running the updated tests against Metis and Forge.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [x] Author referenced issue(s) fixed by this PR: [FE-10764](https://omnisci.atlassian.net/browse/FE-10764)

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [x] author crafted PR's title into release-worthy commit message.
