### PR TITLE
[FE-12564] - added logValues to renderVega and getResultRowForPixel calls

### DIFF
--- a/dist/browser-connector.js
+++ b/dist/browser-connector.js
@@ -48517,10 +48517,6 @@ var MapdCon = /*#__PURE__*/function () {
 
       var curNonce = (this._nonce++).toString();
 
-      if (options) {
-        curNonce = options.hasOwnProperty("logValues") ? JSON.stringify(options.logValues) : curNonce;
-      }
-
       if (!callback) {
         return this.processPixelResults(undefined, // eslint-disable-line no-undefined
         this._client[this._lastRenderCon].get_result_row_for_pixel(this._sessionId[this._lastRenderCon], widgetId, pixel, tableColNamesMap, columnFormat, pixelRadius, curNonce));

--- a/dist/browser-connector.js
+++ b/dist/browser-connector.js
@@ -48461,6 +48461,11 @@ var MapdCon = /*#__PURE__*/function () {
 
       var lastQueryTime = queryId in this.queryTimes ? this.queryTimes[queryId] : this.DEFAULT_QUERY_TIME;
       var curNonce = (this._nonce++).toString();
+
+      if (options) {
+        curNonce = options.hasOwnProperty("logValues") ? JSON.stringify(options.logValues) : curNonce;
+      }
+
       var conId = 0;
       this._lastRenderCon = conId;
       var processResultsOptions = {
@@ -48511,6 +48516,10 @@ var MapdCon = /*#__PURE__*/function () {
       var columnFormat = true; // BOOL
 
       var curNonce = (this._nonce++).toString();
+
+      if (options) {
+        curNonce = options.hasOwnProperty("logValues") ? JSON.stringify(options.logValues) : curNonce;
+      }
 
       if (!callback) {
         return this.processPixelResults(undefined, // eslint-disable-line no-undefined

--- a/dist/node-connector.js
+++ b/dist/node-connector.js
@@ -48366,10 +48366,6 @@ var MapdCon = /*#__PURE__*/function () {
 
       var curNonce = (this._nonce++).toString();
 
-      if (options) {
-        curNonce = options.hasOwnProperty("logValues") ? JSON.stringify(options.logValues) : curNonce;
-      }
-
       if (!callback) {
         return this.processPixelResults(undefined, // eslint-disable-line no-undefined
         this._client[this._lastRenderCon].get_result_row_for_pixel(this._sessionId[this._lastRenderCon], widgetId, pixel, tableColNamesMap, columnFormat, pixelRadius, curNonce));

--- a/dist/node-connector.js
+++ b/dist/node-connector.js
@@ -48310,6 +48310,11 @@ var MapdCon = /*#__PURE__*/function () {
 
       var lastQueryTime = queryId in this.queryTimes ? this.queryTimes[queryId] : this.DEFAULT_QUERY_TIME;
       var curNonce = (this._nonce++).toString();
+
+      if (options) {
+        curNonce = options.hasOwnProperty("logValues") ? JSON.stringify(options.logValues) : curNonce;
+      }
+
       var conId = 0;
       this._lastRenderCon = conId;
       var processResultsOptions = {
@@ -48360,6 +48365,10 @@ var MapdCon = /*#__PURE__*/function () {
       var columnFormat = true; // BOOL
 
       var curNonce = (this._nonce++).toString();
+
+      if (options) {
+        curNonce = options.hasOwnProperty("logValues") ? JSON.stringify(options.logValues) : curNonce;
+      }
 
       if (!callback) {
         return this.processPixelResults(undefined, // eslint-disable-line no-undefined

--- a/src/mapd-con-es6.js
+++ b/src/mapd-con-es6.js
@@ -972,7 +972,7 @@ export class MapdCon {
       curNonce = options.hasOwnProperty("logValues")
         ? JSON.stringify(options.logValues)
         : curNonce
-    }
+      }
 
     const lastQueryTime =
       queryId in this.queryTimes
@@ -1609,7 +1609,12 @@ export class MapdCon {
         ? this.queryTimes[queryId]
         : this.DEFAULT_QUERY_TIME
 
-    const curNonce = (this._nonce++).toString()
+    let curNonce = (this._nonce++).toString()
+    if (options) {
+      curNonce = options.hasOwnProperty("logValues")
+        ? JSON.stringify(options.logValues)
+        : curNonce
+    }
 
     const conId = 0
     this._lastRenderCon = conId
@@ -1684,7 +1689,12 @@ export class MapdCon {
     }
 
     const columnFormat = true // BOOL
-    const curNonce = (this._nonce++).toString()
+    let curNonce = (this._nonce++).toString()
+    if (options) {
+      curNonce = options.hasOwnProperty("logValues")
+        ? JSON.stringify(options.logValues)
+        : curNonce
+      }
 
     if (!callback) {
       return this.processPixelResults(

--- a/src/mapd-con-es6.js
+++ b/src/mapd-con-es6.js
@@ -972,7 +972,7 @@ export class MapdCon {
       curNonce = options.hasOwnProperty("logValues")
         ? JSON.stringify(options.logValues)
         : curNonce
-      }
+    }
 
     const lastQueryTime =
       queryId in this.queryTimes
@@ -1689,12 +1689,7 @@ export class MapdCon {
     }
 
     const columnFormat = true // BOOL
-    let curNonce = (this._nonce++).toString()
-    if (options) {
-      curNonce = options.hasOwnProperty("logValues")
-        ? JSON.stringify(options.logValues)
-        : curNonce
-      }
+    const curNonce = (this._nonce++).toString()
 
     if (!callback) {
       return this.processPixelResults(


### PR DESCRIPTION
Small tweak - it's the same mod that went into #194 to use `options.logValues` as the nonce (if present) in query calls.

This mod puts the same functionality into `renderVega` calls.

You can test this by pointing to this connector hash and opening up a log viewer - you should see dashboardId/chartId logged out for renderVega calls as well as query calls.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
