### PR TITLE
Update the examples to showcase arrow wire

### DIFF
--- a/examples/browser.html
+++ b/examples/browser.html
@@ -1,40 +1,162 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <base data-ice="baseUrl">
   <title data-ice="title">Connector Example</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
   <style>
-  .axis {
-    font: 10px sans-serif;
-  }
+    #query  {
+      font-family: 'SF Mono', 'Monaco', 'Courier New', Courier, monospace;
+      font-weight: 500;
+    }
 
-  .axis path,
-  .axis line {
-    fill: none;
-    stroke: #000;
-    shape-rendering: crispEdges;
-  }
-  rect {
-    opacity: 0.8;
-  }
-  rect:hover{
-    opacity: 1;
-  }
+    .data-view table {
+      font-family: 'SF Mono', 'Monaco', 'Courier New', Courier, monospace;
+    }
+
+    #debug-info {
+      padding: 20px;
+      font-family: 'SF Mono', 'Monaco', 'Courier New', Courier, monospace;
+      max-height: 200px;
+      overflow-y: scroll;
+      background: #ffffff;
+      border: 1px solid #eee;
+    }
   </style>
-
 </head>
-  <body>
-    <p><strong> Example 1: SELECT count(*) AS n FROM tweets_nov_feb WHERE country='CO' </strong></p>
-    <p id="result-async"></p>
 
-    <hr>
+<body>
+  <div class="container-fluid">
+    <div class="row">
+      <div class="pt-2 col-2 sidebar">
 
-    <p><strong> Example 2: SELECT carrier_name as key0, AVG(airtime) AS val FROM flights_donotmodify WHERE airtime IS NOT NULL GROUP BY key0 ORDER BY val DESC LIMIT 20 </strong></p>
-    <div id="chart"></div>
-    <script src="https://unpkg.com/babel-polyfill@6.26.0/dist/polyfill.js"></script>
-    <script src="../dist/browser-connector.js"></script>
-    <script src="https://d3js.org/d3.v3.min.js"></script>
-    <script src="browser.js"></script>
-  </body>
+        <div class="card border-light">
+          <div class="card-header">
+            Tables
+          </div>
+          <ul id="tables" class="list-group list-group-flush">
+          </ul>
+        </div>
+
+      </div>
+
+      <div class="data-view pt-2 col-10">
+
+        <div class="card border-light">
+          <div class="card-header">
+            Query Database
+          </div>
+          <div class="p-4">
+            <form id="queryForm">
+              <div class="input-group mt-3 mb-3">
+                <input type="text" id="query" class="form-control" spellcheck="false" placeholder="SQL Query">
+                <div class="input-group-append">
+                  <button class="btn btn-outline-primary" type="submit" id="execute">Execute</button>
+                </div>
+              </div>
+            </form>
+
+            <div class="">
+              <div class="alert alert-primary" role="alert">
+                Note that geo types are not yet supported for result set to arrow conversion.
+              </div>
+            </div>
+
+            <pre id="debug-info"> </pre>
+
+
+          </div>
+        </div>
+
+        <div class="card">
+          <table class="table table-hover">
+            <thead id="thead">
+            </thead>
+            <tbody id="tbody">
+            </tbody>
+          </table>
+
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <div class="modal fade" data-backdrop="static" id="connect-modal" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Connect to OmniSciDB</h5>
+        </div>
+        <div class="modal-body">
+          <form id="connect-form">
+            <div class="form-group">
+              <label for="hostname">Hostname</label>
+              <input name="hostname" id="hostname" class="form-control">
+            </div>
+            <div class="form-group">
+              <label for="port">Port</label>
+              <input name="port" class="form-control" id="port">
+            </div>
+            <div class="form-group">
+              <label for="database">Database</label>
+              <input name="database" class="form-control" id="database">
+            </div>
+            <div class="form-group">
+              <label for="username">Username</label>
+              <input name="username" class="form-control" id="username">
+            </div>
+            <div class="form-group">
+              <label for="password">Password</label>
+              <input name="password" type="password" class="form-control" id="password">
+            </div>
+            <div class="form-group form-check">
+              <input type="checkbox" class="form-check-input" id="useHTTPS">
+              <label name="useHTTPS" class="form-check-label" for="useHTTPS">Use HTTPS</label>
+            </div>
+            <button type="submit" id="connect" class="btn btn-primary">Connect</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal fade" id="table-info-modal" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title"></h5>
+        </div>
+        <div class="modal-body">
+          <table id="col-list" class="table table-borderless table-sm table-hover">
+            <thead id="thead">
+              <tr>
+                <th>Name</th>
+                <th>Type</th>
+              </tr>
+            </thead>
+            <tbody id="tbody">
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+
+
+
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
+  <script type="text/javascript" src="/dist/browser-connector.js"></script>
+  <script src="https://d3js.org/d3.v3.min.js"></script>
+  <script src="browser.js"></script>
+</body>
+
 </html>

--- a/examples/browser.html
+++ b/examples/browser.html
@@ -154,8 +154,8 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
     crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/apache-arrow@2/Arrow.es5.min.js"></script>
   <script type="text/javascript" src="/dist/browser-connector.js"></script>
-  <script src="https://d3js.org/d3.v3.min.js"></script>
   <script src="browser.js"></script>
 </body>
 

--- a/examples/browser.html
+++ b/examples/browser.html
@@ -1,162 +1,181 @@
 <!DOCTYPE html>
 <html>
+  <head>
+    <meta charset="utf-8" />
+    <base data-ice="baseUrl" />
+    <title data-ice="title">Connector Example</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+      integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2"
+      crossorigin="anonymous"
+    />
+    <style>
+      #query {
+        font-family: "SF Mono", "Monaco", "Courier New", Courier, monospace;
+        font-weight: 500;
+      }
 
-<head>
-  <meta charset="utf-8">
-  <base data-ice="baseUrl">
-  <title data-ice="title">Connector Example</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
-    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <style>
-    #query  {
-      font-family: 'SF Mono', 'Monaco', 'Courier New', Courier, monospace;
-      font-weight: 500;
-    }
+      .data-view table {
+        font-family: "SF Mono", "Monaco", "Courier New", Courier, monospace;
+      }
 
-    .data-view table {
-      font-family: 'SF Mono', 'Monaco', 'Courier New', Courier, monospace;
-    }
+      #debug-info {
+        padding: 20px;
+        font-family: "SF Mono", "Monaco", "Courier New", Courier, monospace;
+        max-height: 200px;
+        overflow-y: scroll;
+        background: #ffffff;
+        border: 1px solid #eee;
+      }
+    </style>
+  </head>
 
-    #debug-info {
-      padding: 20px;
-      font-family: 'SF Mono', 'Monaco', 'Courier New', Courier, monospace;
-      max-height: 200px;
-      overflow-y: scroll;
-      background: #ffffff;
-      border: 1px solid #eee;
-    }
-  </style>
-</head>
-
-<body>
-  <div class="container-fluid">
-    <div class="row">
-      <div class="pt-2 col-2 sidebar">
-
-        <div class="card border-light">
-          <div class="card-header">
-            Tables
+  <body>
+    <div class="container-fluid">
+      <div class="row">
+        <div class="pt-2 col-2 sidebar">
+          <div class="card border-light">
+            <div class="card-header">Tables</div>
+            <ul id="tables" class="list-group list-group-flush"></ul>
           </div>
-          <ul id="tables" class="list-group list-group-flush">
-          </ul>
         </div>
 
-      </div>
+        <div class="data-view pt-2 col-10">
+          <div class="card border-light">
+            <div class="card-header">Query Database</div>
+            <div class="p-4">
+              <form id="queryForm">
+                <div class="input-group mt-3 mb-3">
+                  <input
+                    type="text"
+                    id="query"
+                    class="form-control"
+                    spellcheck="false"
+                    placeholder="SQL Query"
+                  />
+                  <div class="input-group-append">
+                    <button
+                      class="btn btn-outline-primary"
+                      type="submit"
+                      id="execute"
+                    >
+                      Execute
+                    </button>
+                  </div>
+                </div>
+              </form>
 
-      <div class="data-view pt-2 col-10">
-
-        <div class="card border-light">
-          <div class="card-header">
-            Query Database
-          </div>
-          <div class="p-4">
-            <form id="queryForm">
-              <div class="input-group mt-3 mb-3">
-                <input type="text" id="query" class="form-control" spellcheck="false" placeholder="SQL Query">
-                <div class="input-group-append">
-                  <button class="btn btn-outline-primary" type="submit" id="execute">Execute</button>
+              <div class="">
+                <div class="alert alert-primary" role="alert">
+                  Note that geo types are not yet supported for result set to
+                  arrow conversion.
                 </div>
               </div>
-            </form>
 
-            <div class="">
-              <div class="alert alert-primary" role="alert">
-                Note that geo types are not yet supported for result set to arrow conversion.
-              </div>
+              <pre id="debug-info"></pre>
             </div>
+          </div>
 
-            <pre id="debug-info"> </pre>
-
-
+          <div class="card">
+            <table class="table table-hover">
+              <thead id="thead"></thead>
+              <tbody id="tbody"></tbody>
+            </table>
           </div>
         </div>
+      </div>
+    </div>
 
-        <div class="card">
-          <table class="table table-hover">
-            <thead id="thead">
-            </thead>
-            <tbody id="tbody">
-            </tbody>
-          </table>
-
+    <div
+      class="modal fade"
+      data-backdrop="static"
+      id="connect-modal"
+      tabindex="-1"
+    >
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Connect to OmniSciDB</h5>
+          </div>
+          <div class="modal-body">
+            <form id="connect-form">
+              <div class="form-group">
+                <label for="hostname">Hostname</label>
+                <input name="hostname" id="hostname" class="form-control" />
+              </div>
+              <div class="form-group">
+                <label for="port">Port</label>
+                <input name="port" class="form-control" id="port" />
+              </div>
+              <div class="form-group">
+                <label for="database">Database</label>
+                <input name="database" class="form-control" id="database" />
+              </div>
+              <div class="form-group">
+                <label for="username">Username</label>
+                <input name="username" class="form-control" id="username" />
+              </div>
+              <div class="form-group">
+                <label for="password">Password</label>
+                <input
+                  name="password"
+                  type="password"
+                  class="form-control"
+                  id="password"
+                />
+              </div>
+              <div class="form-group form-check">
+                <input type="checkbox" class="form-check-input" id="useHTTPS" />
+                <label name="useHTTPS" class="form-check-label" for="useHTTPS"
+                  >Use HTTPS</label
+                >
+              </div>
+              <button type="submit" id="connect" class="btn btn-primary">
+                Connect
+              </button>
+            </form>
+          </div>
         </div>
       </div>
     </div>
 
-  </div>
-
-  <div class="modal fade" data-backdrop="static" id="connect-modal" tabindex="-1">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title">Connect to OmniSciDB</h5>
-        </div>
-        <div class="modal-body">
-          <form id="connect-form">
-            <div class="form-group">
-              <label for="hostname">Hostname</label>
-              <input name="hostname" id="hostname" class="form-control">
-            </div>
-            <div class="form-group">
-              <label for="port">Port</label>
-              <input name="port" class="form-control" id="port">
-            </div>
-            <div class="form-group">
-              <label for="database">Database</label>
-              <input name="database" class="form-control" id="database">
-            </div>
-            <div class="form-group">
-              <label for="username">Username</label>
-              <input name="username" class="form-control" id="username">
-            </div>
-            <div class="form-group">
-              <label for="password">Password</label>
-              <input name="password" type="password" class="form-control" id="password">
-            </div>
-            <div class="form-group form-check">
-              <input type="checkbox" class="form-check-input" id="useHTTPS">
-              <label name="useHTTPS" class="form-check-label" for="useHTTPS">Use HTTPS</label>
-            </div>
-            <button type="submit" id="connect" class="btn btn-primary">Connect</button>
-          </form>
+    <div class="modal fade" id="table-info-modal" tabindex="-1">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title"></h5>
+          </div>
+          <div class="modal-body">
+            <table
+              id="col-list"
+              class="table table-borderless table-sm table-hover"
+            >
+              <thead id="thead">
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody id="tbody"></tbody>
+            </table>
+          </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <div class="modal fade" id="table-info-modal" tabindex="-1">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title"></h5>
-        </div>
-        <div class="modal-body">
-          <table id="col-list" class="table table-borderless table-sm table-hover">
-            <thead id="thead">
-              <tr>
-                <th>Name</th>
-                <th>Type</th>
-              </tr>
-            </thead>
-            <tbody id="tbody">
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
-  </div>
-
-
-
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
-    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
-    crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
-    crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/apache-arrow@2/Arrow.es5.min.js"></script>
-  <script type="text/javascript" src="/dist/browser-connector.js"></script>
-  <script src="browser.js"></script>
-</body>
-
+    <script
+      src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+      integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+      crossorigin="anonymous"
+    ></script>
+    <script src="https://cdn.jsdelivr.net/npm/apache-arrow@2/Arrow.es5.min.js"></script>
+    <script type="text/javascript" src="/dist/browser-connector.js"></script>
+    <script src="browser.js"></script>
+  </body>
 </html>

--- a/examples/browser.js
+++ b/examples/browser.js
@@ -12,38 +12,36 @@ const defaultConnection = {
   database: "omnisci",
   username: "admin",
   password: "HyperInteractive"
-};
+}
 
 /* 
   Connect Modal 
 */
 function hideConnectModal() {
-  $('#connect-modal').modal('hide')
+  $("#connect-modal").modal("hide")
 }
 
 // Show connect modal
 $(document).ready(function () {
-  $('#connect-modal').modal()
+  $("#connect-modal").modal()
   if (autologin)
     setTimeout(() => {
-      $('#connect-form button').click()
-    }, 300);
+      $("#connect-form button").click()
+    }, 300)
 })
 
 // Populate form
-var connectFormInputs = document.querySelectorAll('#connect-form input');
+var connectFormInputs = document.querySelectorAll("#connect-form input")
 for (const ipt of connectFormInputs) {
-  if (ipt.id === 'useHTTPS')
-    if (defaultConnection.useHTTPS)
-      ipt.checked = true
-  ipt.setAttribute('value', defaultConnection[ipt.id])
+  if (ipt.id === "useHTTPS") if (defaultConnection.useHTTPS) ipt.checked = true
+  ipt.setAttribute("value", defaultConnection[ipt.id])
 }
 
-$('#connect-form').submit(function (evt) {
-  evt.preventDefault();
-  var values = $(this).serializeArray();
-  var useHTTPS = $("input[type='checkbox']#useHTTPS").prop('checked');
-  var protocol = useHTTPS ? 'https' : 'http'
+$("#connect-form").submit(function (evt) {
+  evt.preventDefault()
+  var values = $(this).serializeArray()
+  var useHTTPS = $("input[type='checkbox']#useHTTPS").prop("checked")
+  var protocol = useHTTPS ? "https" : "http"
   let connectionOpts = {
     protocol: protocol
   }
@@ -53,9 +51,9 @@ $('#connect-form').submit(function (evt) {
   tryConnect(connectionOpts)
 })
 
-$('form#queryForm').submit(function (evt) {
+$("form#queryForm").submit(function (evt) {
   evt.preventDefault()
-  var query = $('form input#query').val()
+  var query = $("form input#query").val()
   executeQuery(query)
 })
 
@@ -75,25 +73,27 @@ function tryConnect(connectionOpts) {
       populateQuery(sample_query)
       populateTables()
     })
-    .catch(err => alert(err.error_msg))
+    .catch((err) => alert(err.error_msg))
 }
 
 function executeQuery(query) {
-  connection.queryDFAsync(query, { debug_info: true }, null, (debug_info) => {
-    console.log(debug_info)
-    $('pre#debug-info').append('\n')
-    $('pre#debug-info').append(query + '\n')
-    for (const [key, value] of Object.entries(debug_info)) {
-      $('pre#debug-info').append('  ' + key + ": " + value + "\n")
-    }
-  }).then((results) => {
-    console.log(results)
-    populateResultsTable(results)
-  })
+  connection
+    .queryDFAsync(query, { debug_info: true }, null, (debug_info) => {
+      console.log(debug_info)
+      $("pre#debug-info").append("\n")
+      $("pre#debug-info").append(query + "\n")
+      for (const [key, value] of Object.entries(debug_info)) {
+        $("pre#debug-info").append("  " + key + ": " + value + "\n")
+      }
+    })
+    .then((results) => {
+      console.log(results)
+      populateResultsTable(results)
+    })
 }
 
 function populateQuery(query_str) {
-  $('form input#query').val(query_str)
+  $("form input#query").val(query_str)
 }
 
 function queryFromTableName(table_name) {
@@ -104,73 +104,69 @@ function queryFromTableName(table_name) {
 
 function showTableDetails(evt) {
   let table_name = $(evt.currentTarget).text()
-  $('#table-info-modal h5').text(table_name + " column details")
+  $("#table-info-modal h5").text(table_name + " column details")
   console.log(table_name)
-  Promise.all([
-    connection.getFieldsAsync(table_name),
-  ])
-    .then(values => {
-      let colList = $('#table-info-modal #col-list tbody')
-      colList.empty()
-      console.log(values)
-      for (const col of values[0].columns) {
-        let colEl = $("<tr></tr>")
-        colEl.append("<td>" + col.name + "</td>")
-        colEl.append("<td>" + col.type + "</td>")
-        colList.append(colEl)
-      }
-      $('#table-info-modal').modal('show')
-    })
+  Promise.all([connection.getFieldsAsync(table_name)]).then((values) => {
+    let colList = $("#table-info-modal #col-list tbody")
+    colList.empty()
+    console.log(values)
+    for (const col of values[0].columns) {
+      let colEl = $("<tr></tr>")
+      colEl.append("<td>" + col.name + "</td>")
+      colEl.append("<td>" + col.type + "</td>")
+      colList.append(colEl)
+    }
+    $("#table-info-modal").modal("show")
+  })
 }
 
 function populateTables() {
-  Promise.all([
-    connection.getTablesAsync(),
-  ]).then(values => {
-    let tableContainer = $('ul#tables')
+  Promise.all([connection.getTablesAsync()]).then((values) => {
+    let tableContainer = $("ul#tables")
     tableContainer.empty()
     let addRow = (table_name) => {
-      let new_item = $("<li class='list-group-item list-group-item-action'></li>").text(table_name)
+      let new_item = $(
+        "<li class='list-group-item list-group-item-action'></li>"
+      ).text(table_name)
       new_item.click(showTableDetails.bind())
       tableContainer.append(new_item)
     }
-    values[0].map(x => addRow(x.name))
+    values[0].map((x) => addRow(x.name))
   })
 }
 
 function addCell(tr, type, value) {
   var td = document.createElement(type)
-  td.textContent = value;
-  tr.appendChild(td);
+  td.textContent = value
+  tr.appendChild(td)
 }
 
 function populateResultsTable(arrowTable) {
-  var thead = $(".data-view thead")[0];
-  var tbody = $(".data-view tbody")[0];
+  var thead = $(".data-view thead")[0]
+  var tbody = $(".data-view tbody")[0]
 
   while (thead.hasChildNodes()) {
-    thead.removeChild(thead.lastChild);
+    thead.removeChild(thead.lastChild)
   }
 
   while (tbody.hasChildNodes()) {
-    tbody.removeChild(tbody.lastChild);
+    tbody.removeChild(tbody.lastChild)
   }
 
-  var header_row = document.createElement("tr");
+  var header_row = document.createElement("tr")
   for (let field of arrowTable.schema.fields) {
-    addCell(header_row, "th", `${field}`);
+    addCell(header_row, "th", `${field}`)
   }
 
-  thead.appendChild(header_row);
+  thead.appendChild(header_row)
 
   for (let row of arrowTable) {
-    var tr = document.createElement("tr");
+    var tr = document.createElement("tr")
     for (let cell of row) {
-      let val = 'null';
-      if (cell.length > 1)
-        val = cell[1]
-      addCell(tr, "td", val);
+      let val = "null"
+      if (cell.length > 1) val = cell[1]
+      addCell(tr, "td", val)
     }
-    tbody.appendChild(tr);
+    tbody.appendChild(tr)
   }
 }

--- a/examples/browser.js
+++ b/examples/browser.js
@@ -1,146 +1,176 @@
 /* eslint-disable */
 
-const hostname = "metis.mapd.com"
-const protocol = "https"
-const port = "443"
-const database = "mapd"
-const username = "mapd"
-const password = "HyperInteractive"
-
-// The total number of tweets from Columbia
-const query = "SELECT count(*) AS n FROM tweets_nov_feb WHERE country='CO'"
-// try changing airtime to arrdelay in the query
-const query2 =
-  "SELECT carrier_name as key0, AVG(airtime) AS val FROM flights_donotmodify WHERE airtime IS NOT NULL GROUP BY key0 ORDER BY val DESC LIMIT 100"
+window.connection = null
+const autologin = false
+const sample_query =
+  "SELECT name, ST_Area(omnisci_geo) as val FROM omnisci_counties;"
 const defaultQueryOptions = {}
-const connector = new window.MapdCon()
+const defaultConnection = {
+  hostname: "localhost",
+  useHTTPS: true,
+  port: "6278",
+  database: "omnisci",
+  username: "admin",
+  password: "HyperInteractive"
+};
 
-connector
-  .protocol(protocol)
-  .host(hostname)
-  .port(port)
-  .dbName(database)
-  .user(username)
-  .password(password)
-  .connectAsync()
-  .then(session =>
-    // now that we have a session open we can make some db calls:
-    Promise.all([
-      session.getTablesAsync(),
-      session.getFieldsAsync("flights_donotmodify"),
-      session.queryAsync(query, defaultQueryOptions),
-      session.queryAsync(query2, defaultQueryOptions)
-    ])
-  )
-  // values is an array of results from all the promises above
-  .then(values => {
-    // handle result of getTablesAsync
-    console.log(
-      `All dashboards available at ${hostname}:\n`,
-      values[0].map(x => x.name)
-    )
+/* 
+  Connect Modal 
+*/
+function hideConnectModal() {
+  $('#connect-modal').modal('hide')
+}
 
-    // handle result of getFieldsAsync
-    console.log(
-      "All fields for 'flights_donotmodify':",
-      values[1].columns.reduce((o, x) => Object.assign(o, { [x.name]: x }), {})
-    )
+// Show connect modal
+$(document).ready(function () {
+  $('#connect-modal').modal()
+  if (autologin)
+    setTimeout(() => {
+      $('#connect-form button').click()
+    }, 300);
+})
 
-    // handle result of first query
-    document.getElementById("result-async").innerHTML =
-      "There are " + values[2][0].n + " tweets from Columbia."
-    console.log("Query 1 results:", Number(values[2][0].n))
+// Populate form
+var connectFormInputs = document.querySelectorAll('#connect-form input');
+for (const ipt of connectFormInputs) {
+  if (ipt.id === 'useHTTPS')
+    if (defaultConnection.useHTTPS)
+      ipt.checked = true
+  ipt.setAttribute('value', defaultConnection[ipt.id])
+}
 
-    // handle result of 2nd query
-    createRowChart(values[3])
-    console.log(
-      "Query 2 results:",
-      values[3].reduce((o, x) => Object.assign(o, { [x.key0]: x.val }), {})
-    )
+$('#connect-form').submit(function (evt) {
+  evt.preventDefault();
+  var values = $(this).serializeArray();
+  var useHTTPS = $("input[type='checkbox']#useHTTPS").prop('checked');
+  var protocol = useHTTPS ? 'https' : 'http'
+  let connectionOpts = {
+    protocol: protocol
+  }
+  for (const val of values) {
+    connectionOpts[val.name] = val.value
+  }
+  tryConnect(connectionOpts)
+})
+
+$('form#queryForm').submit(function (evt) {
+  evt.preventDefault()
+  var query = $('form input#query').val()
+  executeQuery(query)
+})
+
+function tryConnect(connectionOpts) {
+  const connector = new MapdCon()
+  connector
+    .protocol(connectionOpts.protocol)
+    .host(connectionOpts.hostname)
+    .port(connectionOpts.port)
+    .dbName(connectionOpts.database)
+    .user(connectionOpts.username)
+    .password(connectionOpts.password)
+    .connectAsync()
+    .then((res) => {
+      window.connection = res
+      hideConnectModal()
+      populateQuery(sample_query)
+      populateTables()
+    })
+    .catch(err => alert(err.error_msg))
+}
+
+function executeQuery(query) {
+  connection.queryDFAsync(query, { debug_info: true }, null, (debug_info) => {
+    console.log(debug_info)
+    $('pre#debug-info').append('\n')
+    $('pre#debug-info').append(query + '\n')
+    for (const [key, value] of Object.entries(debug_info)) {
+      $('pre#debug-info').append('  ' + key + ": " + value + "\n")
+    }
+  }).then((results) => {
+    console.log(results)
+    populateResultsTable(results)
   })
-  .catch(error => {
-    console.error("Something bad happened: ", error)
-  })
+}
 
-// http://bl.ocks.org/d3noob/8952219
-function createRowChart(data) {
-  var margin = { top: 20, right: 20, bottom: 150, left: 40 },
-    width = 600
-  height = 300
+function populateQuery(query_str) {
+  $('form input#query').val(query_str)
+}
 
-  var x = d3.scale.ordinal().rangeRoundBands([0, width], 0.05)
+function queryFromTableName(table_name) {
+  let query = "SELECT * FROM " + table_name
+  populateQuery(query)
+  executeQuery(query)
+}
 
-  var y = d3.scale.linear().range([height, 0])
-
-  var xAxis = d3.svg
-    .axis()
-    .scale(x)
-    .orient("bottom")
-    .tickFormat(function(d, i) {
-      return d
-    })
-
-  var yAxis = d3.svg
-    .axis()
-    .scale(y)
-    .orient("left")
-    .ticks(10)
-
-  var svg = d3
-    .select("#chart")
-    .append("svg")
-    .attr("width", width + margin.left + margin.right)
-    .attr("height", height + margin.top + margin.bottom)
-    .append("g")
-    .attr("transform", "translate(" + margin.left + "," + margin.top + ")")
-
-  x.domain(
-    data.map(function(d) {
-      return d.key0
-    })
-  )
-  y.domain([
-    0,
-    d3.max(data, function(d) {
-      return d.val
-    })
+function showTableDetails(evt) {
+  let table_name = $(evt.currentTarget).text()
+  $('#table-info-modal h5').text(table_name + " column details")
+  console.log(table_name)
+  Promise.all([
+    connection.getFieldsAsync(table_name),
   ])
-
-  svg
-    .append("g")
-    .attr("class", "x axis")
-    .attr("transform", "translate(0," + height + ")")
-    .call(xAxis)
-    .selectAll("text")
-    .style("text-anchor", "end")
-    .attr("dx", "-.8em")
-    .attr("dy", "-.55em")
-    .attr("transform", "rotate(-90)")
-
-  svg
-    .append("g")
-    .attr("class", "y axis")
-    .call(yAxis)
-    .append("text")
-    .attr("transform", "rotate(-90)")
-    .attr("y", 6)
-    .attr("dy", ".71em")
-    .style("text-anchor", "end")
-
-  svg
-    .selectAll("bar")
-    .data(data)
-    .enter()
-    .append("rect")
-    .style("fill", "steelblue")
-    .attr("x", function(d) {
-      return x(d.key0)
+    .then(values => {
+      let colList = $('#table-info-modal #col-list tbody')
+      colList.empty()
+      console.log(values)
+      for (const col of values[0].columns) {
+        let colEl = $("<tr></tr>")
+        colEl.append("<td>" + col.name + "</td>")
+        colEl.append("<td>" + col.type + "</td>")
+        colList.append(colEl)
+      }
+      $('#table-info-modal').modal('show')
     })
-    .attr("width", x.rangeBand())
-    .attr("y", function(d) {
-      return y(d.val)
-    })
-    .attr("height", function(d) {
-      return height - y(d.val)
-    })
+}
+
+function populateTables() {
+  Promise.all([
+    connection.getTablesAsync(),
+  ]).then(values => {
+    let tableContainer = $('ul#tables')
+    tableContainer.empty()
+    let addRow = (table_name) => {
+      let new_item = $("<li class='list-group-item list-group-item-action'></li>").text(table_name)
+      new_item.click(showTableDetails.bind())
+      tableContainer.append(new_item)
+    }
+    values[0].map(x => addRow(x.name))
+  })
+}
+
+function addCell(tr, type, value) {
+  var td = document.createElement(type)
+  td.textContent = value;
+  tr.appendChild(td);
+}
+
+function populateResultsTable(arrowTable) {
+  var thead = $(".data-view thead")[0];
+  var tbody = $(".data-view tbody")[0];
+
+  while (thead.hasChildNodes()) {
+    thead.removeChild(thead.lastChild);
+  }
+
+  while (tbody.hasChildNodes()) {
+    tbody.removeChild(tbody.lastChild);
+  }
+
+  var header_row = document.createElement("tr");
+  for (let field of arrowTable.schema.fields) {
+    addCell(header_row, "th", `${field}`);
+  }
+
+  thead.appendChild(header_row);
+
+  for (let row of arrowTable) {
+    var tr = document.createElement("tr");
+    for (let cell of row) {
+      let val = 'null';
+      if (cell.length > 1)
+        val = cell[1]
+      addCell(tr, "td", val);
+    }
+    tbody.appendChild(tr);
+  }
 }

--- a/examples/node.js
+++ b/examples/node.js
@@ -25,7 +25,7 @@ connector
   .user(username)
   .password(password)
   .connectAsync()
-  .then(session =>
+  .then((session) =>
     // now that we have a session open we can make some db calls:
     Promise.all([
       session.getDashboardsAsync(),
@@ -36,17 +36,17 @@ connector
     ])
   )
   // values is an array of results from all the promises above
-  .then(values => {
+  .then((values) => {
     // handle result of getDashboardsAsync
     console.log(
       `All dashboards available at ${hostname}:\n`,
-      values[0].map(dash => dash.dashboard_name)
+      values[0].map((dash) => dash.dashboard_name)
     )
 
     // handle result of getTablesAsync
     console.log(
       `\nAll tables available at ${hostname}:\n\n`,
-      values[1].map(x => x.name)
+      values[1].map((x) => x.name)
     )
 
     // handle result of getFieldsAsync
@@ -64,6 +64,6 @@ connector
       values[4].reduce((o, x) => Object.assign(o, { [x.key0]: x.val }), {})
     )
   })
-  .catch(error => {
+  .catch((error) => {
     console.error("Something bad happened: ", error)
   })


### PR DESCRIPTION
This was leftover in my branch where I was using rollup + the nodejs version of Thrift on the browser. 


It looks like this...

Connect Modal:
<img width="1531" alt="Screen Shot 2020-12-11 at 10 17 54 PM" src="https://user-images.githubusercontent.com/1047986/101971350-c521f100-3bfe-11eb-8988-7caf04f34ed8.png">

Query (using Arrow Wire) results:
<img width="1525" alt="Screen Shot 2020-12-11 at 10 16 16 PM" src="https://user-images.githubusercontent.com/1047986/101971315-85f3a000-3bfe-11eb-93a1-52ba79fd7cef.png">

Clicking on a table in the sidebar shows you some schema information.
<img width="1535" alt="Screen Shot 2020-12-11 at 10 18 07 PM" src="https://user-images.githubusercontent.com/1047986/101971371-de2aa200-3bfe-11eb-8e39-fe7c143e6d49.png">

