### PR TITLE
[FE-12702] :bug: return error from queryDF

### DIFF
--- a/dist/browser-connector.js
+++ b/dist/browser-connector.js
@@ -31442,6 +31442,10 @@ var MapdCon = /*#__PURE__*/function () {
       var limit = -1;
       var conId = 0;
       var args = [this._sessionId[conId], query, TDeviceType.CPU, deviceId, limit, TArrowTransport.WIRE, function (err, data) {
+        if (err) {
+          return callback(err, null);
+        }
+
         var buf = Buffer.from(data.df_buffer, "base64");
         var results = external_commonjs_apache_arrow_commonjs2_apache_arrow_amd_apache_arrow_root_Arrow_.Table.from(buf);
 

--- a/dist/node-connector.js
+++ b/dist/node-connector.js
@@ -31447,6 +31447,10 @@ var MapdCon = /*#__PURE__*/function () {
       var limit = -1;
       var conId = 0;
       var args = [this._sessionId[conId], query, TDeviceType.CPU, deviceId, limit, TArrowTransport.WIRE, function (err, data) {
+        if (err) {
+          return callback(err, null);
+        }
+
         var buf = Buffer.from(data.df_buffer, "base64");
         var results = external_apache_arrow_namespaceObject.Table.from(buf);
 

--- a/src/mapd-con-es6.js
+++ b/src/mapd-con-es6.js
@@ -1062,6 +1062,10 @@ export class MapdCon {
       limit,
       TArrowTransport.WIRE,
       (err, data) => {
+        if (err) {
+          return callback(err, null)
+        }
+
         const buf = Buffer.from(data.df_buffer, "base64")
         let results = Table.from(buf)
         if (options && Boolean(options.returnTiming)) {


### PR DESCRIPTION
If there's an error in queryDF, `data` will be undefined/null, so the first line (which references `data.df_buffer`) will throw an error. We need to call the callback with the error before that happens.